### PR TITLE
Task/actions checkout v3

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: brew install xcodegen
       - name: Check Carthage project
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: yarn --cwd "$scripts" install --frozen-lockfile
       - name: Lint JavaScript
@@ -63,7 +63,7 @@ jobs:
     environment: LCP
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: brew install xcodegen
       - name: Generate project
@@ -86,7 +86,7 @@ jobs:
     environment: LCP
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: brew install xcodegen
       - name: Generate project
@@ -105,7 +105,7 @@ jobs:
     environment: LCP
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: brew install xcodegen
       - name: Generate project
@@ -126,7 +126,7 @@ jobs:
     environment: LCP
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: brew install xcodegen
       - name: Generate project


### PR DESCRIPTION
To fix the warning we get when running workflows:
`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16`
